### PR TITLE
Synchronize confidential computing page encryption status

### DIFF
--- a/kernel-open/nvidia-uvm/uvm_conf_computing.c
+++ b/kernel-open/nvidia-uvm/uvm_conf_computing.c
@@ -32,6 +32,8 @@
 #include "uvm_tracker.h"
 #include "nv_uvm_interface.h"
 #include "uvm_va_block.h"
+#include "uvm_migrate_pageable.h"
+#include <linux/migrate.h>
 
 
 static UvmGpuConfComputeMode uvm_conf_computing_get_mode(const uvm_parent_gpu_t *parent)
@@ -498,4 +500,85 @@ void uvm_conf_computing_fault_increment_decrypt_iv(uvm_parent_gpu_t *parent_gpu,
                                           NULL);
 
     UVM_ASSERT(status == NV_OK);
+}
+
+NV_STATUS uvm_conf_computing_quiesce_cpu_access(struct mm_struct *mm,
+                                                unsigned long start,
+                                                unsigned long length)
+{
+    return uvm_conf_computing_quiesce_cpu_access_with_fn(mm, start, length, NULL, NULL);
+}
+
+NV_STATUS uvm_conf_computing_quiesce_cpu_access_with_fn(struct mm_struct *mm,
+                                                        unsigned long start,
+                                                        unsigned long length,
+                                                        NV_STATUS (*switch_fn)(unsigned long, unsigned long, void *),
+                                                        void *switch_arg)
+{
+    struct vm_area_struct *vma;
+    unsigned long outer = start + length;
+    NV_STATUS status = NV_OK;
+
+    UVM_ASSERT(PAGE_ALIGNED(start));
+    UVM_ASSERT(PAGE_ALIGNED(length));
+
+    if (!mm || length == 0)
+        return NV_ERR_INVALID_ARGUMENT;
+
+    uvm_down_read_mmap_lock(mm);
+
+    vma = find_vma_intersection(mm, start, outer);
+    if (!vma || (start < vma->vm_start)) {
+        status = NV_ERR_INVALID_ADDRESS;
+        goto out_unlock;
+    }
+
+    for (; vma && vma->vm_start <= outer; vma = find_vma_intersection(mm, vma->vm_end, outer)) {
+        unsigned long cur = max(start, vma->vm_start);
+        unsigned long end = min(outer, vma->vm_end);
+
+        if (!vma_is_anonymous(vma))
+            continue;
+
+        while (cur < end) {
+            unsigned long chunk_end = min(cur + UVM_MIGRATE_VMA_MAX_SIZE, end);
+            struct migrate_vma args = {
+                .vma = vma,
+                .start = cur,
+                .end = chunk_end,
+            };
+#if defined(NV_MIGRATE_VMA_FLAGS_PRESENT)
+            args.flags = 0;
+#endif
+            {
+                int ret = migrate_vma_setup(&args);
+                if (ret < 0) {
+                    status = errno_to_nv_status(ret);
+                    goto out_unlock;
+                }
+
+                if (switch_fn) {
+                    NV_STATUS fn_status = switch_fn(cur, chunk_end - cur, switch_arg);
+                    if (fn_status != NV_OK) {
+                        status = fn_status;
+                        // Still finalize to restore mappings before returning
+                        migrate_vma_finalize(&args);
+                        goto out_unlock;
+                    }
+                }
+
+                // We're only using migrate_vma as a quiesce barrier. No page moves.
+                migrate_vma_pages(&args);
+                migrate_vma_finalize(&args);
+            }
+            cur = chunk_end;
+        }
+
+        if (vma->vm_end >= outer)
+            break;
+    }
+
+out_unlock:
+    uvm_up_read_mmap_lock(mm);
+    return status;
 }

--- a/kernel-open/nvidia-uvm/uvm_conf_computing.h
+++ b/kernel-open/nvidia-uvm/uvm_conf_computing.h
@@ -199,4 +199,17 @@ NV_STATUS uvm_conf_computing_fault_decrypt(uvm_parent_gpu_t *parent_gpu,
 //
 // Locking: this function must be invoked while holding the replayable ISR lock.
 void uvm_conf_computing_fault_increment_decrypt_iv(uvm_parent_gpu_t *parent_gpu, NvU64 increment);
+
+NV_STATUS uvm_conf_computing_quiesce_cpu_access(struct mm_struct *mm,
+                                                unsigned long start,
+                                                unsigned long length);
+
+// Quiesce CPU access over [start, start+length) by installing migration entries
+// and invoke switch_fn within the quiesce window to flip CC state.
+// If switch_fn is NULL, the function simply quiesces briefly and restores.
+NV_STATUS uvm_conf_computing_quiesce_cpu_access_with_fn(struct mm_struct *mm,
+                                                        unsigned long start,
+                                                        unsigned long length,
+                                                        NV_STATUS (*switch_fn)(unsigned long, unsigned long, void *),
+                                                        void *switch_arg);
 #endif // __UVM_CONF_COMPUTING_H__

--- a/kernel-open/nvidia-uvm/uvm_test.c
+++ b/kernel-open/nvidia-uvm/uvm_test.c
@@ -219,6 +219,12 @@ static NV_STATUS uvm_test_cgroup_accounting_supported(UVM_TEST_CGROUP_ACCOUNTING
     return UVM_CGROUP_ACCOUNTING_SUPPORTED() ? NV_OK : NV_ERR_NOT_SUPPORTED;
 }
 
+static NV_STATUS uvm_test_cc_quiesce_cpu_access(UVM_TEST_CC_QUIESCE_CPU_ACCESS_PARAMS *params, struct file *filp)
+{
+    struct mm_struct *mm = current->mm;
+    return uvm_conf_computing_quiesce_cpu_access(mm, params->start, params->length);
+}
+
 long uvm_test_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
     // Disable all test entry points if the module parameter wasn't provided.
@@ -333,6 +339,7 @@ long uvm_test_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TEST_SPLIT_INVALIDATE_DELAY, uvm_test_split_invalidate_delay);
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TEST_CPU_CHUNK_API, uvm_test_cpu_chunk_api);
         UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TEST_SKIP_MIGRATE_VMA, uvm_test_skip_migrate_vma);
+        UVM_ROUTE_CMD_STACK_INIT_CHECK(UVM_TEST_CC_QUIESCE_CPU_ACCESS,         uvm_test_cc_quiesce_cpu_access);
     }
 
     return -EINVAL;


### PR DESCRIPTION
Add a `migrate_vma`-based helper to safely transition confidential computing page states by blocking concurrent CPU access.

Confidential computing page encryption state and PTE C-bit updates are not atomic. Concurrent access during private↔shared transitions can lead to security vulnerabilities. This PR leverages the page migration mechanism, replacing PTEs with migration entries, to serialize access and ensure atomic state changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-707eab48-5685-43e7-8002-c2893c2520c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-707eab48-5685-43e7-8002-c2893c2520c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

