### PR TITLE
Print RmIoctl pParms members in NV_ESC_RM_ALLOC_MEMORY

### DIFF
--- a/src/nvidia/arch/nvalloc/unix/src/escape.c
+++ b/src/nvidia/arch/nvalloc/unix/src/escape.c
@@ -301,6 +301,18 @@ NV_STATUS RmIoctl(
             pApi = data;
             pParms = &pApi->params;
 
+            // Print all members of pParms (NVOS02_PARAMETERS)
+            NV_PRINTF(LEVEL_INFO, "=== NVOS02_PARAMETERS members ===\n");
+            NV_PRINTF(LEVEL_INFO, "pParms->hRoot: 0x%x\n", pParms->hRoot);
+            NV_PRINTF(LEVEL_INFO, "pParms->hObjectParent: 0x%x\n", pParms->hObjectParent);
+            NV_PRINTF(LEVEL_INFO, "pParms->hObjectNew: 0x%x\n", pParms->hObjectNew);
+            NV_PRINTF(LEVEL_INFO, "pParms->hClass: 0x%x\n", pParms->hClass);
+            NV_PRINTF(LEVEL_INFO, "pParms->flags: 0x%x\n", pParms->flags);
+            NV_PRINTF(LEVEL_INFO, "pParms->pMemory: 0x%llx\n", (unsigned long long)pParms->pMemory);
+            NV_PRINTF(LEVEL_INFO, "pParms->limit: 0x%llx\n", (unsigned long long)pParms->limit);
+            NV_PRINTF(LEVEL_INFO, "pParms->status: 0x%x\n", pParms->status);
+            NV_PRINTF(LEVEL_INFO, "=== End NVOS02_PARAMETERS members ===\n");
+
             NV_ACTUAL_DEVICE_ONLY(nv);
 
             if (dataSize != sizeof(nv_ioctl_nvos02_parameters_with_fd))

--- a/src/nvidia/arch/nvalloc/unix/src/escape.c
+++ b/src/nvidia/arch/nvalloc/unix/src/escape.c
@@ -302,16 +302,16 @@ NV_STATUS RmIoctl(
             pParms = &pApi->params;
 
             // Print all members of pParms (NVOS02_PARAMETERS)
-            NV_PRINTF(LEVEL_INFO, "=== NVOS02_PARAMETERS members ===\n");
-            NV_PRINTF(LEVEL_INFO, "pParms->hRoot: 0x%x\n", pParms->hRoot);
-            NV_PRINTF(LEVEL_INFO, "pParms->hObjectParent: 0x%x\n", pParms->hObjectParent);
-            NV_PRINTF(LEVEL_INFO, "pParms->hObjectNew: 0x%x\n", pParms->hObjectNew);
-            NV_PRINTF(LEVEL_INFO, "pParms->hClass: 0x%x\n", pParms->hClass);
-            NV_PRINTF(LEVEL_INFO, "pParms->flags: 0x%x\n", pParms->flags);
-            NV_PRINTF(LEVEL_INFO, "pParms->pMemory: 0x%llx\n", (unsigned long long)pParms->pMemory);
-            NV_PRINTF(LEVEL_INFO, "pParms->limit: 0x%llx\n", (unsigned long long)pParms->limit);
-            NV_PRINTF(LEVEL_INFO, "pParms->status: 0x%x\n", pParms->status);
-            NV_PRINTF(LEVEL_INFO, "=== End NVOS02_PARAMETERS members ===\n");
+            NV_PRINTF(LEVEL_NOTICE, "=== NVOS02_PARAMETERS members ===\n");
+            NV_PRINTF(LEVEL_NOTICE, "pParms->hRoot: 0x%x\n", pParms->hRoot);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->hObjectParent: 0x%x\n", pParms->hObjectParent);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->hObjectNew: 0x%x\n", pParms->hObjectNew);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->hClass: 0x%x\n", pParms->hClass);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->flags: 0x%x\n", pParms->flags);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->pMemory: 0x%llx\n", (unsigned long long)pParms->pMemory);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->limit: 0x%llx\n", (unsigned long long)pParms->limit);
+            NV_PRINTF(LEVEL_NOTICE, "pParms->status: 0x%x\n", pParms->status);
+            NV_PRINTF(LEVEL_NOTICE, "=== End NVOS02_PARAMETERS members ===\n");
 
             NV_ACTUAL_DEVICE_ONLY(nv);
 


### PR DESCRIPTION
Add logging to print `NVOS02_PARAMETERS` members in `RmIoctl`'s `NV_ESC_RM_ALLOC_MEMORY` case for debugging memory allocation.

---
<a href="https://cursor.com/background-agent?bcId=bc-397ca0ee-789c-459b-a67c-ecf89bc05693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-397ca0ee-789c-459b-a67c-ecf89bc05693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

