### PR TITLE
CudaMalloc ioctl difference

### DIFF
--- a/analysis-cudamalloc-vs-vmm-ioctl-0x2a.md
+++ b/analysis-cudamalloc-vs-vmm-ioctl-0x2a.md
@@ -1,0 +1,206 @@
+# cudaMalloc vs VMM API：nvidiactl 0x2a ioctl 差异分析
+
+## 1. ioctl 命令码对照表
+
+根据 NVIDIA 开源内核驱动源码 `src/nvidia/arch/nvalloc/unix/include/nv_escape.h`：
+
+| ioctl 编码 | 宏定义 | 含义 |
+|-----------|--------|------|
+| **0x2A** | `NV_ESC_RM_CONTROL` | RM Control 调用（通用控制命令分发接口） |
+| **0x2B** | `NV_ESC_RM_ALLOC` | RM 对象分配（创建 RM 内部对象） |
+
+根据 `kernel-open/nvidia-uvm/uvm_ioctl.h`（Linux 下 `UVM_IOCTL_BASE(i)` = `i`）：
+
+| ioctl 编码 | 十进制值 | 宏定义 | 含义 |
+|-----------|---------|--------|------|
+| **0x49** | 73 | `UVM_CREATE_EXTERNAL_RANGE` | 在 UVM VA space 中创建外部范围 |
+| **0x21** | 33 | `UVM_MAP_EXTERNAL_ALLOCATION` | 将 RM 分配的物理内存映射到 UVM 管理的 VA |
+
+## 2. 两条路径的系统调用对比
+
+### cudaMalloc 路径
+
+```
+ioctl(/dev/nvidiactl, 0x2b, 0x30) = 0   # NV_ESC_RM_ALLOC: 分配物理内存对象 + GPU VA 映射对象
+ioctl(/dev/nvidiactl, 0x2a, 0x20) = 0   # NV_ESC_RM_CONTROL: 【额外的】RM 控制命令 ★
+ioctl(/dev/nvidia-uvm, 0x49)      = 0   # UVM_CREATE_EXTERNAL_RANGE: 在 UVM 中注册 VA 范围
+ioctl(/dev/nvidia-uvm, 0x21)      = 0   # UVM_MAP_EXTERNAL_ALLOCATION: 映射物理内存到该 VA
+```
+
+### VMM API 路径 (cuMemAddressReserve + cuMemCreate + cuMemMap + cuMemSetAccess)
+
+```
+RESERVE:  mmap(PROT_NONE, MAP_FIXED)              # 纯用户态 VA 预留，无 nvidiactl ioctl
+CREATE:   ioctl(/dev/nvidiactl, 0x2b, 0x30) = 0   # NV_ESC_RM_ALLOC: 仅分配物理内存句柄
+MAP:      (无额外 syscall)                          # 映射关系在后续 SETACC 中一并完成
+SETACC:   ioctl(/dev/nvidia-uvm, 0x49)      = 0   # UVM_CREATE_EXTERNAL_RANGE
+          ioctl(/dev/nvidia-uvm, 0x21)      = 0   # UVM_MAP_EXTERNAL_ALLOCATION
+```
+
+**关键差异：cudaMalloc 多了一次 `NV_ESC_RM_CONTROL`（0x2a），VMM 路径没有。**
+
+## 3. NV_ESC_RM_CONTROL (0x2a) 的作用
+
+### 3.1 它是什么
+
+`NV_ESC_RM_CONTROL`（0x2a）是 NVIDIA Resource Manager (RM) 的**通用控制命令分发接口**。它本身不是一个具体操作，而是一个"信封"——通过 `NVOS54_PARAMETERS` 结构体中的 `cmd` 字段携带真正的控制命令 ID：
+
+```c
+// src/common/sdk/nvidia/inc/nvos.h
+typedef struct {
+    NvHandle hClient;      // 客户端句柄
+    NvHandle hObject;      // 目标对象句柄
+    NvV32    cmd;          // ★ 真正的控制命令 ID
+    NvU32    flags;
+    NvP64    params;       // 命令参数指针
+    NvU32    paramsSize;   // 参数大小
+    NvV32    status;       // 返回状态
+} NVOS54_PARAMETERS;
+```
+
+内核侧处理逻辑见 `escape.c` 第 711-773 行：收到 `NV_ESC_RM_CONTROL` 后，内核解包 `NVOS54_PARAMETERS` 并分发到 `Nv04ControlWithSecInfo()`。
+
+### 3.2 在 cudaMalloc 中它具体做了什么
+
+在 cudaMalloc 的上下文中，这个 `NV_ESC_RM_CONTROL` 调用最可能执行的是以下操作之一（或组合）：
+
+#### 最可能的场景：GPU 虚拟地址空间（VA Space）内部管理操作
+
+cudaMalloc 是一个**一体化的高层 API**，它在内部需要完成：
+
+1. 分配物理显存（通过 `NV_ESC_RM_ALLOC` / 0x2b）
+2. **在 GPU VA space 中分配/保留一段虚拟地址范围，并将 PA 绑定到 VA**
+3. 注册到 UVM 并建立映射
+
+第 2 步就是这个 `NV_ESC_RM_CONTROL` 的用途。具体来说，它很可能是发送了以下控制命令之一：
+
+- **`NV0080_CTRL_CMD_DMA_*` 系列**：Device 级别的 DMA/VA 管理控制命令，用于在 RM 内部的 GPU VA space 中保留/管理虚拟地址范围
+- **`NV90F1_CTRL_CMD_VASPACE_*` 系列**：直接操作 FERMI_VASPACE_A 对象的 VA space 管理命令
+
+这些命令的核心功能是：**让 RM 在 GPU 页表结构中为这次分配预留 VA 范围，并建立 VA→PA 的映射关系**（即操作 GPU MMU 的 PDE/PTE）。
+
+### 3.3 具体可能的 RM Control 命令
+
+根据 strace 中 `0x20`（32 字节）的参数大小匹配 `NVOS54_PARAMETERS` 结构体大小，内嵌的 `cmd` 字段可能是：
+
+| 候选命令 | 说明 |
+|---------|------|
+| `NV0080_CTRL_CMD_DMA_SET_PAGE_DIRECTORY` | 设置页目录，管理 GPU 页表层级 |
+| `NV0080_CTRL_CMD_DMA_UPDATE_PDE_2` | 更新 PDE（Page Directory Entry），在 GPU 页表中建立映射 |
+| `NV90F1_CTRL_CMD_VASPACE_RESERVE_ENTRIES` | 在 VA space 中锁定/保留页表项 |
+| 其他内部 VA 管理命令 | RM 内部统一虚拟内存管理 |
+
+最大的可能性是 **GPU 页表相关操作**——cudaMalloc 需要在 RM 层面通知内核驱动："我要在 GPU VA space 的某个范围建立到物理内存的映射，请更新 GPU 页表"。
+
+## 4. 为什么 VMM API 路径不需要这个 0x2a 调用
+
+这是两种 API 在**设计哲学**上的根本差异导致的：
+
+### 4.1 cudaMalloc：RM 主导的一体化管理
+
+```
+用户调用 cudaMalloc(size)
+    └── CUDA Runtime 内部：
+        ├── (1) NV_ESC_RM_ALLOC (0x2b)
+        │       → RM 分配物理内存对象
+        │       → RM 可能同时创建关联的 VA mapping 对象
+        │
+        ├── (2) NV_ESC_RM_CONTROL (0x2a)  ★ 额外步骤
+        │       → RM 在 GPU VA space 中保留虚拟地址范围
+        │       → RM 更新 GPU 页表（PDE/PTE）建立 VA→PA 映射
+        │       → 这一步由 RM 统一管理，用户无感知
+        │
+        ├── (3) UVM_CREATE_EXTERNAL_RANGE (0x49)
+        │       → 在 UVM 子系统中注册这段地址范围
+        │
+        └── (4) UVM_MAP_EXTERNAL_ALLOCATION (0x21)
+                → UVM 建立自己的映射追踪结构
+```
+
+cudaMalloc 让 **RM（Resource Manager）完全掌控** GPU 虚拟地址的分配和页表管理。RM 需要通过 `NV_ESC_RM_CONTROL` 来执行这些内部管理操作。
+
+### 4.2 VMM API：用户主导的分离式管理
+
+```
+cuMemAddressReserve(ptr, size)        # 用户自己预留 VA 范围
+    └── mmap(PROT_NONE, MAP_FIXED)    # 仅 CPU 侧 VA 保留，GPU VA 由 UVM 直接管理
+                                       # 不走 RM 的 VA space 分配逻辑
+
+cuMemCreate(handle, size)             # 创建物理内存句柄
+    └── NV_ESC_RM_ALLOC (0x2b)        # 仅分配物理内存，不涉及 VA 映射
+
+cuMemMap(ptr, size, handle)           # 建立 VA→PA 映射
+    └── (无额外 syscall)               # 映射关系记录在用户态，
+                                       # 延迟到 cuMemSetAccess 时一并下发
+
+cuMemSetAccess(ptr, size, ...)        # 设置访问权限 + 实际完成映射
+    ├── UVM_CREATE_EXTERNAL_RANGE      # UVM 直接管理 VA 范围
+    └── UVM_MAP_EXTERNAL_ALLOCATION    # UVM 直接建立 VA→PA 映射
+```
+
+VMM API 路径的关键区别：
+
+1. **VA 预留绕过了 RM**：`cuMemAddressReserve` 用 `mmap(PROT_NONE)` 在 CPU 侧预留地址空间，GPU 侧的 VA 管理交给 UVM 直接处理，不需要通过 RM 的 `NV_ESC_RM_CONTROL` 来操作 GPU 页表
+2. **物理内存分配与 VA 映射解耦**：`cuMemCreate` 只创建物理内存句柄，不立即绑定到任何 VA
+3. **映射由 UVM 直接完成**：`cuMemSetAccess` 阶段直接通过 UVM ioctl 完成 GPU 页表的更新，UVM 子系统有自己独立的页表管理路径，不依赖 RM 的控制命令
+
+### 4.3 一句话总结差异原因
+
+> **cudaMalloc 在 RM 层面进行 GPU VA 分配和页表绑定（需要 `RM_CONTROL`），而 VMM API 将 VA 管理权下放给 UVM 子系统直接处理（绕过 RM 的控制路径）。**
+
+## 5. 架构层面的含义
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    用户态 (CUDA)                      │
+│  ┌──────────────┐        ┌───────────────────────┐  │
+│  │  cudaMalloc   │        │  VMM API (显式管理)     │  │
+│  │  (一体化)      │        │  Reserve/Create/       │  │
+│  │              │         │  Map/SetAccess         │  │
+│  └──────┬───────┘        └──────────┬────────────┘  │
+├─────────┼───────────────────────────┼───────────────┤
+│         │        内核态              │                │
+│  ┌──────▼───────┐              ┌────▼────┐          │
+│  │  nvidiactl    │              │nvidia-uvm│          │
+│  │  (RM 驱动)    │              │(UVM 驱动) │          │
+│  │              │              │          │          │
+│  │ 0x2b: Alloc  │              │ 0x49:    │          │
+│  │ 0x2a: Control│◄─cudaMalloc  │ CreateExt│          │
+│  │  (VA管理/    │  需要RM统一   │ Range    │          │
+│  │   页表操作)   │  管理VA       │          │          │
+│  │              │              │ 0x21:    │          │
+│  │              │   VMM路径─────►│ MapExt   │          │
+│  │              │   直接走UVM    │ Alloc    │          │
+│  └──────────────┘              └─────────┘          │
+│                                                      │
+│        ┌──────────────────────────────┐              │
+│        │      GPU 硬件 (页表/MMU)      │              │
+│        └──────────────────────────────┘              │
+└─────────────────────────────────────────────────────┘
+```
+
+## 6. 性能影响
+
+这个额外的 `NV_ESC_RM_CONTROL` 调用意味着：
+
+- **cudaMalloc** 路径每次分配/释放都需要**额外一次内核态往返**（ioctl syscall），用于 RM 层面的 VA space 管理
+- **VMM API** 路径通过将 VA 管理直接交给 UVM，减少了与 RM 驱动的交互次数
+- 在高频小分配场景下，这个差异可能累积成可观的开销，这也是 VMM API（配合 memory pool）在某些场景下性能更优的原因之一
+
+## 7. 关于 free 路径
+
+你提到 cudaMalloc 的 free 路径也有 0x2a ioctl，这与分配路径是对称的：
+- 分配时：RM_CONTROL 用于在 GPU VA space 中建立映射
+- 释放时：RM_CONTROL 用于在 GPU VA space 中解除映射并回收 VA 范围
+
+VMM API 的释放路径（cuMemUnmap + cuMemRelease + cuMemAddressFree）同样不需要这个 RM_CONTROL，因为 VA 管理始终由 UVM 侧处理。
+
+## 参考源码位置
+
+- ioctl 命令码定义：`src/nvidia/arch/nvalloc/unix/include/nv_escape.h`
+- ioctl 分发处理：`src/nvidia/arch/nvalloc/unix/src/escape.c` (RmIoctl 函数)
+- NVOS54 (RM Control) 参数结构：`src/common/sdk/nvidia/inc/nvos.h`
+- UVM ioctl 定义：`kernel-open/nvidia-uvm/uvm_ioctl.h`
+- UVM 外部范围创建：`kernel-open/nvidia-uvm/uvm_map_external.c`
+- VA Space 控制命令：`src/common/sdk/nvidia/inc/ctrl/ctrl90f1.h`
+- Device DMA 控制命令：`src/common/sdk/nvidia/inc/ctrl/ctrl0080/ctrl0080dma.h`


### PR DESCRIPTION
Add analysis document explaining the `nvidiactl` 0x2a ioctl difference between `cudaMalloc` and VMM API memory allocation.

---
<p><a href="https://cursor.com/agents?id=bc-b80d16ce-b836-4cb5-b8b6-f7a35c444394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b80d16ce-b836-4cb5-b8b6-f7a35c444394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

